### PR TITLE
Android ChromeでFABがフッタにめり込む問題を修正(アドレスバーが隠れるとheightが変わるので。高速でスクロールすると再…

### DIFF
--- a/app/assets/javascripts/layout.js.rb
+++ b/app/assets/javascripts/layout.js.rb
@@ -26,7 +26,7 @@ def init_footer_and_fab
       moving_footer.show
       fab.css('bottom', "16px")
       Window.on(:scroll) do |e|
-        bottom = `$(window).scrollTop()` + height - moving_footer.offset.top
+        bottom = `$(window).scrollTop() + $(window).innerHeight()` - moving_footer.offset.top
         if bottom >= 0
           # FAB移動
           fab.css('bottom', "#{bottom + 16}px")


### PR DESCRIPTION
…発する問題が残っている)
